### PR TITLE
Use Home Assistant MQTT settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The POS-Printer Bridge integration allows Home Assistant to send print jobs over
 
 1. Go to **Settings → Devices & Services → Integrations**.
 2. Click **Add Integration** and search for **POS-Printer Bridge**.
-3. Enter your MQTT broker address and a printer name.
+3. Enter a printer name. The MQTT settings from Home Assistant are used automatically.
 
 ### Options
-After setup, adjust the MQTT broker or printer name via **Configure** on the integration entry.
+After setup, you can adjust the printer name via **Configure** on the integration entry.
 
 ## Services
 

--- a/custom_components/pos_printer/config_flow.py
+++ b/custom_components/pos_printer/config_flow.py
@@ -1,10 +1,9 @@
 import json
 import voluptuous as vol
 from homeassistant import config_entries
-from .const import DOMAIN, CONF_MQTT_BROKER, CONF_PRINTER_NAME
+from .const import DOMAIN, CONF_PRINTER_NAME
 
 STEP_USER_DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_MQTT_BROKER): str,
     vol.Required(CONF_PRINTER_NAME, default="kitchen_printer"): str,
 })
 
@@ -29,10 +28,7 @@ class PosPrinterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(
             title=printer_name,
-            data={
-                CONF_PRINTER_NAME: printer_name,
-                CONF_MQTT_BROKER: data.get(CONF_MQTT_BROKER, ""),
-            },
+            data={CONF_PRINTER_NAME: printer_name},
         )
 
     async def async_step_user(self, user_input=None):
@@ -75,10 +71,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_options = self.config_entry.options
 
         data_schema = vol.Schema({
-            vol.Required(
-                CONF_MQTT_BROKER,
-                default=current_options.get(CONF_MQTT_BROKER, current_data.get(CONF_MQTT_BROKER)),
-            ): str,
             vol.Required(
                 CONF_PRINTER_NAME,
                 default=current_options.get(CONF_PRINTER_NAME, current_data.get(CONF_PRINTER_NAME)),

--- a/custom_components/pos_printer/const.py
+++ b/custom_components/pos_printer/const.py
@@ -1,4 +1,3 @@
 DOMAIN = "pos_printer"
-CONF_MQTT_BROKER = "mqtt_broker"
 CONF_PRINTER_NAME = "printer_name"
 

--- a/custom_components/pos_printer/translations/de.json
+++ b/custom_components/pos_printer/translations/de.json
@@ -7,7 +7,6 @@
         "user": {
           "title": "POS-Printer Bridge einrichten",
           "data": {
-            "mqtt_broker": "MQTT-Broker",
             "printer_name": "Druckername"
           }
         }
@@ -32,7 +31,6 @@
         "user": {
           "title": "POS-Printer Bridge Optionen",
           "data": {
-            "mqtt_broker": "MQTT-Broker",
             "printer_name": "Druckername"
           }
         }

--- a/custom_components/pos_printer/translations/en.json
+++ b/custom_components/pos_printer/translations/en.json
@@ -6,7 +6,6 @@
         "user": {
           "title": "Set up POS-Printer Bridge",
           "data": {
-            "mqtt_broker": "MQTT broker",
             "printer_name": "Printer name"
           }
         }
@@ -31,7 +30,6 @@
         "user": {
           "title": "POS-Printer Bridge options",
           "data": {
-            "mqtt_broker": "MQTT broker",
             "printer_name": "Printer name"
           }
         }


### PR DESCRIPTION
## Summary
- rely on HA configured MQTT broker
- remove broker option from UI and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68867d6853088332b7c92aa65cde49fd