### PR TITLE
Add print_job service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ After setup, you can adjust the printer name via **Configure** on the integratio
 
 | Service              | Description                                           |
 |----------------------|-------------------------------------------------------|
-| `pos_printer.print`  | Send a print job with automatic `job_id`, `priority`, `message` |
+| `pos_printer.print`  | Send print elements with automatic `job_id` |
+| `pos_printer.print_job` | Send a full job object |
 
-### Service Fields
+### Service Fields for `print`
 - **priority**: Print priority (0–9, 0 = highest).
 - **message**: List of print elements (text, barcode, image).
+
+### Service Fields for `print_job`
+- **job**: Full job JSON matching `job.schema.json`.
 
 ## Sensors
 

--- a/custom_components/pos_printer/printer.py
+++ b/custom_components/pos_printer/printer.py
@@ -13,6 +13,7 @@ async def setup_print_service(hass: HomeAssistant, config: dict):
 
     # Dienst registrieren
     async def handle_print(call):
+        """Send simplified print data via MQTT."""
         job_id = call.data.get("job_id") or uuid.uuid4().hex
         payload = {
             "job_id": job_id,
@@ -26,7 +27,19 @@ async def setup_print_service(hass: HomeAssistant, config: dict):
             qos=1,
         )
 
+    async def handle_print_job(call):
+        """Send full job object via MQTT."""
+        job = dict(call.data.get("job", {}))
+        job.setdefault("job_id", uuid.uuid4().hex)
+        await mqtt.async_publish(
+            hass,
+            topic=PRINT_TOPIC,
+            payload=json.dumps(job),
+            qos=1,
+        )
+
     hass.services.async_register(DOMAIN, "print", handle_print)
+    hass.services.async_register(DOMAIN, "print_job", handle_print_job)
 
     # Status-Antworten abonnieren
     @callback

--- a/custom_components/pos_printer/services.yaml
+++ b/custom_components/pos_printer/services.yaml
@@ -1,23 +1,30 @@
 print:
   name: "Print POS Job"
-  description: "Send a full print job (text, barcode, image) via MQTT to the bridge."
+  description: "Send a simple print job via MQTT with automatic job_id generation."
+  fields:
+    job_id:
+      description: "Optional job identifier"
+      example: "abc123"
+    priority:
+      description: "Print priority (0-9, 0 = highest)"
+      example: 5
+    message:
+      description: "List of elements to print"
+      example: |
+        - type: text
+          content: "Hello, World!"
+          orientation: center
+
+print_job:
+  name: "Send Full POS Job"
+  description: "Send a full job object as defined in job.schema.json."
   fields:
     job:
-      description: "Job JSON matching job.schema.json"
+      description: "Complete job object"
       example: |
         {
           "priority": 5,
           "message": [
-            {
-              "type": "text",
-              "content": "Hello, World!",
-              "orientation": "center",
-              "bold": true
-            },
-            {
-              "type": "barcode",
-              "content": "12345678",
-              "barcode_type": "code128"
-            }
+            {"type": "text", "content": "Hello"}
           ]
-
+        }

--- a/custom_components/pos_printer/tests/test_service.py
+++ b/custom_components/pos_printer/tests/test_service.py
@@ -53,3 +53,25 @@ async def test_print_service_publishes(mqtt_publish_mock):
     assert payload["job_id"]
     assert payload["message"][0]["content"] == "Hello"
 
+
+@pytest.mark.asyncio
+async def test_print_job_service_publishes(mqtt_publish_mock):
+    """Test sending a full job dictionary."""
+    hass = FakeHass()
+    config = {"printer_name": "printer"}
+    await setup_print_service(hass, config)
+    job = {
+        "priority": 4,
+        "message": [{"type": "text", "content": "Hi"}],
+    }
+    await hass.services.async_call(
+        DOMAIN,
+        "print_job",
+        {"job": job},
+        blocking=True,
+    )
+    call = mqtt_publish_mock[-1]
+    payload = json.loads(call["payload"])
+    assert payload["priority"] == 4
+    assert payload["message"][0]["content"] == "Hi"
+

--- a/custom_components/pos_printer/translations/de.json
+++ b/custom_components/pos_printer/translations/de.json
@@ -54,6 +54,16 @@
             "description": "Liste der zu druckenden Elemente."
           }
         }
+      },
+      "print_job": {
+        "name": "Vollständigen Auftrag senden",
+        "description": "Sendet ein komplettes Auftragsobjekt über MQTT.",
+        "fields": {
+          "job": {
+            "name": "Auftrag",
+            "description": "Auftrags-JSON entsprechend job.schema.json"
+          }
+        }
       }
     }
   }

--- a/custom_components/pos_printer/translations/en.json
+++ b/custom_components/pos_printer/translations/en.json
@@ -44,6 +44,13 @@
           "priority": {"name": "Priority", "description": "Print priority (0-9, 0 = highest)."},
           "message": {"name": "Message", "description": "List of elements to print."}
         }
+      },
+      "print_job": {
+        "name": "Send full job",
+        "description": "Send a complete job object to the POS printer.",
+        "fields": {
+          "job": {"name": "Job", "description": "Job JSON matching job.schema.json"}
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- support sending full print jobs via new `print_job` service
- document service options and translations
- update README with details
- test new service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688695a9a224833286c5740aef19cc34