### PR TITLE
Wait for MQTT client before subscribing

### DIFF
--- a/custom_components/pos_printer/manifest.json
+++ b/custom_components/pos_printer/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "documentation": "https://github.com/fro3hnel/ha-pos-printer-custom-component",
   "requirements": [],
+  "dependencies": ["mqtt"],
   "config_flow": true,
   "iot_class": "local_push",
   "codeowners": ["@fro3hnel"],

--- a/custom_components/pos_printer/printer.py
+++ b/custom_components/pos_printer/printer.py
@@ -7,6 +7,10 @@ from .const import DOMAIN
 
 
 async def setup_print_service(hass: HomeAssistant, config: dict):
+    """Register print services and MQTT status listener."""
+
+    # Ensure the MQTT integration is available before using it
+    await mqtt.async_wait_for_mqtt_client(hass)
 
     PRINT_TOPIC = f"print/pos/{config['printer_name']}/job"
     STATUS_TOPIC = f"print/pos/{config['printer_name']}/ack"

--- a/custom_components/pos_printer/tests/test_service.py
+++ b/custom_components/pos_printer/tests/test_service.py
@@ -31,7 +31,13 @@ def mqtt_publish_mock(monkeypatch):
     calls = []
     async def fake_publish(hass, topic, payload, qos):
         calls.append({"topic": topic, "payload": payload, "qos": qos})
+    async def fake_wait_for_client(hass):
+        return
     monkeypatch.setattr("homeassistant.components.mqtt.async_publish", fake_publish)
+    monkeypatch.setattr(
+        "homeassistant.components.mqtt.async_wait_for_mqtt_client",
+        fake_wait_for_client,
+    )
     return calls
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Wait for MQTT client before publishing/subscribing
- Declare dependency on MQTT in the integration manifest
- Adjust tests to mock MQTT client wait

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b07867488332b9b6aaf5910a41d8