### PR TITLE
Use consistent alignment naming

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -118,9 +118,9 @@ sudo systemctl enable --now pos-printer.service
   "priority": 5,
   "paper_width": 80,
   "message": [
-    {"type": "text", "orientation": "center", "content": "Weather report", "bold": true},
-    {"type": "text", "orientation": "center", "content": "15.07.2025", "underline": true},
-    {"type": "text", "orientation": "left", "content": "15.07: cloudy, 25°C/14°C"},
+    {"type": "text", "alignment": "center", "content": "Weather report", "bold": true},
+    {"type": "text", "alignment": "center", "content": "15.07.2025", "underline": true},
+    {"type": "text", "alignment": "left", "content": "15.07: cloudy, 25°C/14°C"},
     {"type": "barcode", "barcode_type": "qr-code", "content": "https://wetter.de/city"}
   ]
 }

--- a/bridge/printer_bridge.py
+++ b/bridge/printer_bridge.py
@@ -243,7 +243,7 @@ class BixolonPrinter:
                     if t == "text":
                         self._txt(
                             item["content"] + "\n",
-                            item.get("orientation", "left"),
+                            item.get("alignment", "left"),
                         )
                     elif t == "barcode":
                         self._print_barcode(item)

--- a/bridge/tests/test-message.json
+++ b/bridge/tests/test-message.json
@@ -6,19 +6,19 @@
     "message": [
         {
             "type": "text",
-            "orientation": "center",
+            "alignment": "center",
             "content": "Weather report",
             "bold": true
         },
         {
             "type": "text",
-            "orientation": "center",
+            "alignment": "center",
             "content": "15.07.2025",
             "underline": true
         },
         {
             "type": "text",
-            "orientation": "left",
+            "alignment": "left",
             "content": "15.07: cloudy, 25°C/14°C"
         },
         {

--- a/custom_components/pos_printer/services.yaml
+++ b/custom_components/pos_printer/services.yaml
@@ -11,9 +11,9 @@ print:
     message:
       description: "List of elements to print"
       example: |
-        - type: text
-          content: "Hello, World!"
-          orientation: center
+          - type: text
+            content: "Hello, World!"
+            alignment: center
 
 print_job:
   name: "Send Full POS Job"
@@ -23,12 +23,12 @@ print_job:
       description: "List of elements to print (text, barcode, image)"
       example: |
         [
-          {
-            "type": "text",
-            "content": "Hello, World!",
-            "orientation": "center",
-            "bold": true
-          },
+            {
+              "type": "text",
+              "content": "Hello, World!",
+              "alignment": "center",
+              "bold": true
+            },
           {
             "type": "barcode",
             "content": "12345678",

--- a/schema/job.schema.json
+++ b/schema/job.schema.json
@@ -49,11 +49,11 @@
   },
 
   "$defs": {
-    "Orientation": {
-      "type": "string",
-      "enum": ["left", "center", "right"],
-      "default": "left"
-    },
+    "Alignment": {
+        "type": "string",
+        "enum": ["left", "center", "right"],
+        "default": "left"
+      },
 
     "MessageElement": {
       "oneOf": [
@@ -69,7 +69,7 @@
       "required": ["type", "content"],
       "properties": {
         "type": { "const": "text" },
-        "orientation": { "$ref": "#/$defs/Orientation" },
+        "alignment": { "$ref": "#/$defs/Alignment" },
         "content": { "type": "string" },
         "bold": { "type": "boolean" },
         "underline": { "type": "boolean" },
@@ -94,7 +94,6 @@
       "required": ["type", "content", "barcode_type"],
       "properties": {
         "type": { "const": "barcode" },
-        "orientation": { "$ref": "#/$defs/Orientation" },
         "content": { "type": "string" },
         "barcode_type": {
           "type": "string",
@@ -126,7 +125,7 @@
           "$comment": "2D barcode mode or model"
         },
         "alignment": {
-          "$ref": "#/$defs/Orientation",
+          "$ref": "#/$defs/Alignment",
           "$comment": "Horizontal alignment of barcode"
         },
         "textPosition": {
@@ -148,7 +147,7 @@
       "required": ["type", "content"],
       "properties": {
         "type": { "const": "image" },
-        "orientation": { "$ref": "#/$defs/Orientation" },
+        "alignment": { "$ref": "#/$defs/Alignment" },
         "content": {
           "type": "string",
           "contentEncoding": "base64",


### PR DESCRIPTION
## Summary
- Replace "orientation" with "alignment" across printer bridge and schema
- Update service examples and documentation to use alignment terminology
- Adjust schema definitions to expose Alignment enum for all elements

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b6bfdad8833285defb1323e944dd