### PR TITLE
Remove print_job service and extend print

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,30 @@ After setup, you can adjust the printer name via **Configure** on the integratio
 
 | Service              | Description                                           |
 |----------------------|-------------------------------------------------------|
-| `pos_printer.print`  | Send print elements with automatic `job_id` |
-| `pos_printer.print_job` | Send a full job object |
+| `pos_printer.print`  | Send print elements or a full job object with automatic `job_id` |
 
 ### Service Fields for `print`
 - **priority**: Print priority (0–9, 0 = highest).
 - **message**: List of print elements (text, barcode, image).
+- **job**: Complete job JSON matching `job.schema.json`.
 
-### Service Fields for `print_job`
-- **job**: Full job JSON matching `job.schema.json`.
+### Example Service Call
+```yaml
+service: pos_printer.print
+data:
+  priority: 4
+  message:
+    - type: text
+      content: "Scan this code"
+      orientation: center
+    - type: barcode
+      content: "012345678905"
+      barcode_type: ean13
+      alignment: center
+    - type: image
+      content: "iVBORw0KGgoAAAANSUhEUgAAAAUA"
+      nv_key: 1
+```
 
 ## Sensors
 

--- a/custom_components/pos_printer/printer.py
+++ b/custom_components/pos_printer/printer.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import uuid
 from homeassistant.core import HomeAssistant, callback
@@ -17,27 +16,29 @@ async def setup_print_service(hass: HomeAssistant, config: dict):
 
     # Dienst registrieren
     async def handle_print(call):
-        """Send simplified print data via MQTT."""
-        job_id = call.data.get("job_id") or uuid.uuid4().hex
-        # Support both the new 'message' format and deprecated 'job'
-        message = call.data.get("message")
-        priority = call.data.get("priority")
-        if message is None and (job := call.data.get("job")):
+        """Send print data via MQTT.
+
+        Accepts either a simplified ``message`` or a full ``job`` structure.
+        """
+        if (job := call.data.get("job")) is not None:
             if isinstance(job, str):
                 try:
                     job = json.loads(job)
                 except json.JSONDecodeError:
                     job = {}
-            message = job.get("message")
-            if priority is None:
-                priority = job.get("priority")
-        if priority is None:
-            priority = 5
-        payload = {
-            "job_id": job_id,
-            "priority": priority,
-            "message": message,
-        }
+            job.setdefault("job_id", call.data.get("job_id") or uuid.uuid4().hex)
+            await mqtt.async_publish(
+                hass,
+                topic=PRINT_TOPIC,
+                payload=json.dumps(job),
+                qos=1,
+            )
+            return
+
+        job_id = call.data.get("job_id") or uuid.uuid4().hex
+        message = call.data.get("message")
+        priority = call.data.get("priority", 5)
+        payload = {"job_id": job_id, "priority": priority, "message": message}
         await mqtt.async_publish(
             hass,
             topic=PRINT_TOPIC,
@@ -45,19 +46,7 @@ async def setup_print_service(hass: HomeAssistant, config: dict):
             qos=1,
         )
 
-    async def handle_print_job(call):
-        """Send full job object via MQTT."""
-        job = dict(call.data.get("job", {}))
-        job.setdefault("job_id", uuid.uuid4().hex)
-        await mqtt.async_publish(
-            hass,
-            topic=PRINT_TOPIC,
-            payload=json.dumps(job),
-            qos=1,
-        )
-
     hass.services.async_register(DOMAIN, "print", handle_print)
-    hass.services.async_register(DOMAIN, "print_job", handle_print_job)
 
     # Status-Antworten und Heartbeats abonnieren
     @callback

--- a/custom_components/pos_printer/services.yaml
+++ b/custom_components/pos_printer/services.yaml
@@ -1,6 +1,6 @@
 print:
   name: "Print POS Job"
-  description: "Send a simple print job via MQTT with automatic job_id generation."
+  description: "Send a print job or full job object via MQTT with automatic job_id generation."
   fields:
     job_id:
       description: "Optional job identifier"
@@ -12,27 +12,28 @@ print:
       description: "List of elements to print"
       example: |
         - type: text
-          content: "Hello, World!"
+          content: "Scan this code"
           orientation: center
-
-print_job:
-  name: "Send Full POS Job"
-  description: "Send a full job object as defined in job.schema.json."
-  fields:
-    message:
-      description: "List of elements to print (text, barcode, image)"
+        - type: barcode
+          content: "012345678905"
+          barcode_type: ean13
+          alignment: center
+        - type: image
+          content: "iVBORw0KGgoAAAANSUhEUgAAAAUA"
+          nv_key: 1
+    job:
+      description: "Complete job object as defined in job.schema.json"
       example: |
-        [
-          {
-            "type": "text",
-            "content": "Hello, World!",
-            "orientation": "center",
-            "bold": true
-          },
-          {
-            "type": "barcode",
-            "content": "12345678",
-            "barcode_type": "code128"
-          }
-        ]
+        priority: 4
+        message:
+          - type: text
+            content: "Scan this code"
+            orientation: center
+          - type: barcode
+            content: "012345678905"
+            barcode_type: ean13
+            alignment: center
+          - type: image
+            content: "iVBORw0KGgoAAAANSUhEUgAAAAUA"
+            nv_key: 1
 

--- a/custom_components/pos_printer/tests/test_service.py
+++ b/custom_components/pos_printer/tests/test_service.py
@@ -61,8 +61,8 @@ async def test_print_service_publishes(mqtt_publish_mock):
 
 
 @pytest.mark.asyncio
-async def test_print_job_service_publishes(mqtt_publish_mock):
-    """Test sending a full job dictionary."""
+async def test_print_service_with_job_publishes(mqtt_publish_mock):
+    """Test that the print service handles a full job dictionary."""
     hass = FakeHass()
     config = {"printer_name": "printer"}
     await setup_print_service(hass, config)
@@ -72,7 +72,7 @@ async def test_print_job_service_publishes(mqtt_publish_mock):
     }
     await hass.services.async_call(
         DOMAIN,
-        "print_job",
+        "print",
         {"job": job},
         blocking=True,
     )

--- a/custom_components/pos_printer/translations/de.json
+++ b/custom_components/pos_printer/translations/de.json
@@ -45,7 +45,7 @@
     "services": {
       "print": {
         "name": "Druckauftrag senden",
-        "description": "Sendet einen Druckauftrag an den POS-Drucker.",
+        "description": "Sendet einen Druckauftrag oder ein komplettes Auftragsobjekt.",
         "fields": {
           "job_id": {
             "name": "Auftrags-ID",
@@ -58,16 +58,10 @@
           "message": {
             "name": "Nachricht",
             "description": "Liste der zu druckenden Elemente."
-          }
-        }
-      },
-      "print_job": {
-        "name": "Vollständigen Auftrag senden",
-        "description": "Sendet ein komplettes Auftragsobjekt über MQTT.",
-        "fields": {
+          },
           "job": {
             "name": "Auftrag",
-            "description": "Auftrags-JSON entsprechend job.schema.json"
+            "description": "Komplettes Auftrags-JSON entsprechend job.schema.json"
           }
         }
       }

--- a/custom_components/pos_printer/translations/en.json
+++ b/custom_components/pos_printer/translations/en.json
@@ -44,18 +44,12 @@
     "services": {
       "print": {
         "name": "Send print job",
-        "description": "Send a print job to the POS printer.",
+        "description": "Send a print job or full job object to the POS printer.",
         "fields": {
           "job_id": {"name": "Job ID", "description": "Unique job identifier."},
           "priority": {"name": "Priority", "description": "Print priority (0-9, 0 = highest)."},
-          "message": {"name": "Message", "description": "List of elements to print."}
-        }
-      },
-      "print_job": {
-        "name": "Send full job",
-        "description": "Send a complete job object to the POS printer.",
-        "fields": {
-          "job": {"name": "Job", "description": "Job JSON matching job.schema.json"}
+          "message": {"name": "Message", "description": "List of elements to print."},
+          "job": {"name": "Job", "description": "Complete job JSON matching job.schema.json"}
         }
       }
     }


### PR DESCRIPTION
## Summary
- drop deprecated `print_job` service and fold functionality into `print`
- document new `job` field and update translations and services schema
- expand service examples with barcode and image elements

## Testing
- `pytest --asyncio-mode=auto`


------
https://chatgpt.com/codex/tasks/task_e_68a0b911f7b48332a27f9f6186395e8d