### PR TITLE
Support multiple POS printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The POS-Printer Bridge integration allows Home Assistant to send print jobs over
 
 1. Go to **Settings → Devices & Services → Integrations**.
 2. Click **Add Integration** and search for **POS-Printer Bridge**.
-3. Enter a printer name. The MQTT settings from Home Assistant are used automatically.
+3. Enter a printer name. Repeat the setup to add multiple printers; each printer
+   uses its own MQTT topics based on the chosen name.
 
 ### Options
 After setup, you can adjust the printer name via **Configure** on the integration entry.
@@ -30,6 +31,7 @@ After setup, you can adjust the printer name via **Configure** on the integratio
 | `pos_printer.print`  | Send print elements or a full job object with automatic `job_id` |
 
 ### Service Fields for `print`
+- **printer_name**: Target printer (required if more than one printer is configured).
 - **priority**: Print priority (0–9, 0 = highest).
 - **message**: List of print elements (text, barcode, image).
 - **job**: Complete job JSON matching `job.schema.json`.

--- a/custom_components/pos_printer/__init__.py
+++ b/custom_components/pos_printer/__init__.py
@@ -1,6 +1,6 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from .printer import setup_print_service
+from .printer import setup_print_service, unload_print_service
 from .const import DOMAIN
 
 PLATFORMS = ["sensor", "binary_sensor", "update", "button"]
@@ -18,6 +18,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a POS-Printer Bridge config entry."""
+    await unload_print_service(hass, entry.data)
     entry.runtime_data = None
     await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     return True

--- a/custom_components/pos_printer/sensor.py
+++ b/custom_components/pos_printer/sensor.py
@@ -82,6 +82,8 @@ class LastJobStatusSensor(PosPrinterEntity, SensorEntity):
 
     @callback
     def _handle_event(self, event: Event) -> None:
+        if event.data.get("printer_name") != self._printer_name:
+            return
         status = event.data.get("status")
         if status is not None:
             self._state = status
@@ -115,6 +117,8 @@ class LastJobIdSensor(PosPrinterEntity, SensorEntity):
 
     @callback
     def _handle_event(self, event: Event) -> None:
+        if event.data.get("printer_name") != self._printer_name:
+            return
         job_id = event.data.get("job_id")
         if job_id is not None:
             self._state = job_id
@@ -153,6 +157,8 @@ class LastStatusTimestampSensor(PosPrinterEntity, SensorEntity):
 
     @callback
     def _handle_event(self, event: Event) -> None:
+        if event.data.get("printer_name") != self._printer_name:
+            return
         ts = event.data.get("timestamp")
         if isinstance(ts, (int, float)):
             self._timestamp = ts
@@ -184,6 +190,8 @@ class JobErrorBinarySensor(PosPrinterEntity, BinarySensorEntity):
 
     @callback
     def _handle_event(self, event: Event) -> None:
+        if event.data.get("printer_name") != self._printer_name:
+            return
         status = event.data.get("status")
         is_error = status == "error"
         # Nur Notification erzeugen, wenn Status jetzt auf Error wechselt
@@ -233,6 +241,8 @@ class SuccessfulJobsCounterSensor(PosPrinterEntity, SensorEntity):
 
     @callback
     def _handle_event(self, event: Event) -> None:
+        if event.data.get("printer_name") != self._printer_name:
+            return
         if event.data.get("status") == "success":
             self._count += 1
             if self.hass and self.entity_id:

--- a/custom_components/pos_printer/services.yaml
+++ b/custom_components/pos_printer/services.yaml
@@ -2,6 +2,9 @@ print:
   name: "Print POS Job"
   description: "Send a print job or full job object via MQTT with automatic job_id generation."
   fields:
+    printer_name:
+      description: "Name of the target printer"
+      example: "kitchen_printer"
     job_id:
       description: "Optional job identifier"
       example: "abc123"

--- a/custom_components/pos_printer/tests/test_sensor.py
+++ b/custom_components/pos_printer/tests/test_sensor.py
@@ -44,7 +44,18 @@ async def test_sensors_update_states():
     for sensor in sensors:
         sensor.hass = hass
         await sensor.async_added_to_hass()
-    event_data = {"status": "success", "job_id": "1", "timestamp": 1620000000}
+    # Event for a different printer should be ignored
+    hass.bus.async_fire(
+        f"{DOMAIN}.status",
+        {"printer_name": "other", "status": "error", "job_id": "0", "timestamp": 1},
+    )
+    # Matching printer updates sensors
+    event_data = {
+        "printer_name": "printer",
+        "status": "success",
+        "job_id": "1",
+        "timestamp": 1620000000,
+    }
     hass.bus.async_fire(f"{DOMAIN}.status", event_data)
     await hass.async_block_till_done()
     assert sensors[0].state == "success"

--- a/custom_components/pos_printer/tests/test_update.py
+++ b/custom_components/pos_printer/tests/test_update.py
@@ -46,7 +46,11 @@ async def test_update_entity_installs_exact_version(mqtt_publish_mock):
     entity.hass = hass
     await entity.async_added_to_hass()
 
-    heartbeat = {"heartbeat": {"version": "0.0.9"}}
+    # Event from different printer should be ignored
+    hass.bus.async_fire(
+        f"{DOMAIN}.status", {"printer_name": "other", "heartbeat": {"version": "0.0.8"}}
+    )
+    heartbeat = {"printer_name": "printer", "heartbeat": {"version": "0.0.9"}}
     hass.bus.async_fire(f"{DOMAIN}.status", heartbeat)
     await hass.async_block_till_done()
     assert entity.installed_version == "0.0.9"

--- a/custom_components/pos_printer/update.py
+++ b/custom_components/pos_printer/update.py
@@ -65,6 +65,8 @@ class BridgeUpdateEntity(PosPrinterEntity, UpdateEntity):
     @callback
     def _handle_event(self, event: Event) -> None:
         """Handle status or heartbeat events to extract version."""
+        if event.data.get("printer_name") != self._printer_name:
+            return
         heartbeat: dict[str, Any] | None = event.data.get("heartbeat")
         if heartbeat and (version := heartbeat.get("version")):
             if version != self._installed_version:


### PR DESCRIPTION
## Summary
- allow registering multiple POS printers with a single `pos_printer.print` service
- filter status updates by printer so each device only processes its own events
- document printer_name service field

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c0f538648332887160c37c5209af