### PR TITLE
Handle POS printer bus listener cleanup

### DIFF
--- a/custom_components/pos_printer/sensor.py
+++ b/custom_components/pos_printer/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from datetime import datetime, timezone
 import logging
+from typing import Callable
 
 from homeassistant.core import HomeAssistant, callback, Event
 from homeassistant.config_entries import ConfigEntry
@@ -23,6 +24,11 @@ class PosPrinterEntity:
     def __init__(self, printer_name: str, entry_id: str) -> None:
         self._printer_name = printer_name
         self._entry_id = entry_id
+        self._unsub: Callable[[], None] | None = None
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub:
+            self._unsub()
 
     @property
     def device_info(self):
@@ -74,11 +80,9 @@ class LastJobStatusSensor(PosPrinterEntity, SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         # Listen to our custom status events
-        self.hass.bus.async_listen(f"{DOMAIN}.status", self._handle_event)
-
-    async def async_will_remove_from_hass(self) -> None:
-        if hasattr(self, '_unsub'):
-            self._unsub()
+        self._unsub = self.hass.bus.async_listen(
+            f"{DOMAIN}.status", self._handle_event
+        )
 
     @callback
     def _handle_event(self, event: Event) -> None:
@@ -109,11 +113,9 @@ class LastJobIdSensor(PosPrinterEntity, SensorEntity):
         return self._state
 
     async def async_added_to_hass(self) -> None:
-        self.hass.bus.async_listen(f"{DOMAIN}.status", self._handle_event)
-
-    async def async_will_remove_from_hass(self) -> None:
-        if hasattr(self, '_unsub'):
-            self._unsub()
+        self._unsub = self.hass.bus.async_listen(
+            f"{DOMAIN}.status", self._handle_event
+        )
 
     @callback
     def _handle_event(self, event: Event) -> None:
@@ -149,11 +151,9 @@ class LastStatusTimestampSensor(PosPrinterEntity, SensorEntity):
         return datetime.fromtimestamp(self._timestamp, tz=timezone.utc)
 
     async def async_added_to_hass(self) -> None:
-        self.hass.bus.async_listen(f"{DOMAIN}.status", self._handle_event)
-
-    async def async_will_remove_from_hass(self) -> None:
-        if hasattr(self, '_unsub'):
-            self._unsub()
+        self._unsub = self.hass.bus.async_listen(
+            f"{DOMAIN}.status", self._handle_event
+        )
 
     @callback
     def _handle_event(self, event: Event) -> None:
@@ -183,10 +183,6 @@ class JobErrorBinarySensor(PosPrinterEntity, BinarySensorEntity):
     async def async_added_to_hass(self) -> None:
         # Listener speichern zum späteren Abmelden
         self._unsub = self.hass.bus.async_listen(f"{DOMAIN}.status", self._handle_event)
-
-    async def async_will_remove_from_hass(self) -> None:
-        if hasattr(self, "_unsub"):
-            self._unsub()
 
     @callback
     def _handle_event(self, event: Event) -> None:
@@ -233,11 +229,9 @@ class SuccessfulJobsCounterSensor(PosPrinterEntity, SensorEntity):
         return self._count
 
     async def async_added_to_hass(self) -> None:
-        self.hass.bus.async_listen(f"{DOMAIN}.status", self._handle_event)
-
-    async def async_will_remove_from_hass(self) -> None:
-        if hasattr(self, '_unsub'):
-            self._unsub()
+        self._unsub = self.hass.bus.async_listen(
+            f"{DOMAIN}.status", self._handle_event
+        )
 
     @callback
     def _handle_event(self, event: Event) -> None:

--- a/custom_components/pos_printer/tests/test_sensor.py
+++ b/custom_components/pos_printer/tests/test_sensor.py
@@ -17,6 +17,9 @@ class FakeBus:
 
     def async_listen(self, _event, cb):
         self._cbs.append(cb)
+        def _remove():
+            self._cbs.remove(cb)
+        return _remove
 
     def async_fire(self, _event, data):
         for cb in list(self._cbs):
@@ -63,4 +66,21 @@ async def test_sensors_update_states():
     assert sensors[2].native_value.timestamp() == 1620000000
     assert sensors[3].is_on is False
     assert sensors[4].state == 1
+
+
+@pytest.mark.asyncio
+async def test_sensor_removes_listener():
+    """Sensor should remove bus listener when removed from hass."""
+    hass = FakeHass()
+    sensor = LastJobStatusSensor("printer", "entry")
+    sensor.hass = hass
+    await sensor.async_added_to_hass()
+    assert hass.bus._cbs, "Listener was not registered"
+    await sensor.async_will_remove_from_hass()
+    assert not hass.bus._cbs, "Listener was not removed"
+    hass.bus.async_fire(
+        f"{DOMAIN}.status", {"printer_name": "printer", "status": "success"}
+    )
+    await hass.async_block_till_done()
+    assert sensor.state is None
 

--- a/custom_components/pos_printer/update.py
+++ b/custom_components/pos_printer/update.py
@@ -60,7 +60,9 @@ class BridgeUpdateEntity(PosPrinterEntity, UpdateEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register event listener for heartbeat messages."""
-        self.hass.bus.async_listen(f"{DOMAIN}.status", self._handle_event)
+        self._unsub = self.hass.bus.async_listen(
+            f"{DOMAIN}.status", self._handle_event
+        )
 
     @callback
     def _handle_event(self, event: Event) -> None:


### PR DESCRIPTION
## Summary
- track event listener unsubscribe callbacks on sensors and update entity
- ensure listeners are removed when entities unload
- add tests for bus listener cleanup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c57cc6148332aed682342070c151