### PR TITLE
Handle JSON decode errors explicitly and add tests

### DIFF
--- a/custom_components/pos_printer/config_flow.py
+++ b/custom_components/pos_printer/config_flow.py
@@ -16,7 +16,7 @@ class PosPrinterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle MQTT discovery."""
         try:
             data = json.loads(discovery_info["payload"])
-        except Exception:  # noqa: BLE001
+        except json.JSONDecodeError:
             return self.async_abort(reason="invalid_discovery")
 
         printer_name = data.get(CONF_PRINTER_NAME)

--- a/custom_components/pos_printer/tests/test_config_flow.py
+++ b/custom_components/pos_printer/tests/test_config_flow.py
@@ -1,0 +1,16 @@
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.pos_printer.config_flow import PosPrinterConfigFlow
+
+
+@pytest.mark.asyncio
+async def test_mqtt_step_invalid_json():
+    """Invalid discovery payload should abort the flow."""
+    hass = HomeAssistant("")
+    flow = PosPrinterConfigFlow()
+    flow.hass = hass
+    result = await flow.async_step_mqtt({"payload": "not-json"})
+    assert result["type"] == "abort"
+    assert result["reason"] == "invalid_discovery"
+    await hass.async_stop()

--- a/custom_components/pos_printer/tests/test_service.py
+++ b/custom_components/pos_printer/tests/test_service.py
@@ -1,9 +1,23 @@
 """Tests for print service of POS-Printer Bridge."""
 import json
-import pytest
+import logging
 from types import SimpleNamespace
+
+import pytest
+
 from custom_components.pos_printer.printer import setup_print_service
 from custom_components.pos_printer.const import DOMAIN
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def async_listen(self, *args, **kwargs):
+        return
+
+    def async_fire(self, event_type, event_data=None):
+        self.events.append((event_type, event_data))
 
 
 class FakeHass:
@@ -14,7 +28,7 @@ class FakeHass:
         self.services = SimpleNamespace(
             _services={}, async_register=self._register, async_call=self._async_call
         )
-        self.bus = SimpleNamespace(async_listen=lambda *args, **kwargs: None)
+        self.bus = FakeBus()
 
     async def async_block_till_done(self):
         return
@@ -108,4 +122,40 @@ async def test_multiple_printers_publish_to_correct_topic(mqtt_publish_mock):
         blocking=True,
     )
     assert mqtt_publish_mock[-1]["topic"] == "print/pos/two/job"
+
+
+@pytest.mark.asyncio
+async def test_status_handler_invalid_json_and_errors(monkeypatch, caplog):
+    """Ensure status handler ignores invalid JSON and logs other errors."""
+    hass = FakeHass()
+    callbacks = {}
+
+    async def fake_publish(hass, topic, payload, qos):
+        return
+
+    async def fake_wait_for_client(hass):
+        return
+
+    async def fake_subscribe(hass, topic, callback):
+        callbacks[topic] = callback
+        return lambda: None
+
+    monkeypatch.setattr("homeassistant.components.mqtt.async_publish", fake_publish)
+    monkeypatch.setattr(
+        "homeassistant.components.mqtt.async_wait_for_mqtt_client",
+        fake_wait_for_client,
+    )
+    monkeypatch.setattr("homeassistant.components.mqtt.async_subscribe", fake_subscribe)
+
+    await setup_print_service(hass, {"printer_name": "printer"})
+
+    status_cb = callbacks["print/pos/printer/ack"]
+
+    status_cb(SimpleNamespace(payload="not-json"))
+    assert hass.bus.events == []
+
+    with caplog.at_level(logging.ERROR):
+        status_cb(SimpleNamespace(payload="[]"))
+    assert "Error handling status payload" in caplog.text
+    assert hass.bus.events == []
 


### PR DESCRIPTION
## Summary
- use `json.JSONDecodeError` in config flow MQTT discovery
- log unexpected errors during MQTT status handling
- add unit tests for invalid discovery and status payloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c58303a48332ac6b5c06ccbeb4eb