### PR TITLE
chore: tidy imports in printer bridge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.9
+    hooks:
+      - id: ruff
+        args: ["--select=I", "--fix"]

--- a/bridge/printer_bridge.py
+++ b/bridge/printer_bridge.py
@@ -30,31 +30,36 @@ DEFAULT_WIDTH=80
 from __future__ import annotations
 
 import base64
+import io
 import json
 import logging
 import os
 import queue
 import signal
 import subprocess
+import tempfile
 import threading
 import time
+from ctypes import (
+    CDLL,
+    POINTER,
+    RTLD_GLOBAL,
+    Structure,
+    byref,
+    c_bool,
+    c_char_p,
+    c_int,
+    c_ubyte,
+    c_uint,
+)
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List
 
 import paho.mqtt.client as mqtt
 import redis
-from ctypes import (
-    CDLL, RTLD_GLOBAL, c_bool, c_char_p, c_int, c_uint, c_ubyte,
-    Structure, POINTER, byref
-)
-import base64
-import io
-import os
-import tempfile
-from PIL import Image
-
 from dotenv import load_dotenv
+from PIL import Image
 
 try:
     import psutil  # type: ignore


### PR DESCRIPTION
## Summary
- deduplicate and group imports in `printer_bridge.py`
- add pre-commit hook for ruff import sorting

## Testing
- `ruff check --select I --fix bridge/printer_bridge.py`
- `pre-commit run --files bridge/printer_bridge.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c5899e6083328f7253e950afd8de